### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ request.responseType = 'arraybuffer';
 
 request.onload = function() {
   audioContext.decodeAudioData(request.response, function(buffer) {
-    spectro.addSource(buffer, audioContext);
+    spectro.connectSource(buffer, audioContext);
     spectro.start();
   });
 };


### PR DESCRIPTION
`addSource` is no longer available in the spectrogram.js API, so I've updated the example.
