### PR TITLE
Corrected error with the first example setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var spectro = Spectrogram(document.getElementById('canvas'), {
   }
 });
 
-var audioContext = new audioContext();
+var audioContext = new AudioContext();
 var request = new XMLHttpRequest();
 request.open('GET', 'audio.mp3', true);
 request.responseType = 'arraybuffer';


### PR DESCRIPTION
Hi,

Thanks for the awesome library, to start with! While getting it setup I noticed that audioContext should also have the first <b>a</b> capitalized i.e. AudioContext. Not a big issue, but might confuse some people when they are wondering why their code isn't working.